### PR TITLE
差分ビルドの時間を BigQuery にアップロードする。

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -29,10 +29,6 @@ jobs:
       - run: bundle exec danger
         env:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: echo ${{ secrets.SERVICE_ACCOUNT_JSON }} | base64 -d > /tmp/credential.json
-      - run: ./gradlew assembleDebug -PuploadBuildTime=true
-        env:
-          GOOGLE_APPLICATION_CREDENTIALS: "/tmp/credential.json"
       - run: ./gradlew koverXmlReport
       # Codecov
       - uses: codecov/codecov-action@v3

--- a/.github/workflows/upload_incremental_build_time.yml
+++ b/.github/workflows/upload_incremental_build_time.yml
@@ -1,15 +1,10 @@
-name: check
+name: upload_incremental_build_time
 on:
   push:
     branches:
       - main
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
 jobs:
-  check:
+  upload_incremental_build_time:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/upload_incremental_build_time.yml
+++ b/.github/workflows/upload_incremental_build_time.yml
@@ -1,0 +1,31 @@
+name: check
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'adopt'
+          java-version: '17'
+      - uses: gradle/gradle-build-action@v2
+      - run: echo ${{ secrets.SERVICE_ACCOUNT_JSON }} | base64 -d > /tmp/credential.json
+      - name: checkout previous merge commit
+        run: git checkout `git log --merges -n 2 --pretty=format:"%H" | tail -n 1`
+      - run: ./gradlew assembleDebug
+      - run: git checkout main
+      - run: ./gradlew assembleDebug -PuploadBuildTime=true
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: "/tmp/credential.json"


### PR DESCRIPTION
- main へのマージコミットをトリガーにして
- 1個前のマージコミットの assembleDebug Gradle Task を動かし
- main の assembleDebug Gradle Task の所要時間を BigQuery にアップロードする。